### PR TITLE
Templates for enabling giftless service

### DIFF
--- a/ckan/templates/ckan-deployment.yaml
+++ b/ckan/templates/ckan-deployment.yaml
@@ -130,6 +130,16 @@ spec:
         - name: ckan-conf-templates
           mountPath: /etc/ckan-conf/templates
           readOnly: true
+        {{ if .Values.enableGiftless }}
+        - mountPath: /etc/ssh/jwt-rs256.key
+          name: jwt-key
+          readOnly: true
+          subPath: jwt-rs256.key
+        - mountPath: /etc/ssh/jwt-rs256.key.pub
+          name: jwt-key-pub
+          readOnly: true
+          subPath: jwt-rs256.key.pub
+        {{ end }}
         {{ if not .Values.noProbes }}
         readinessProbe:
           httpGet:
@@ -162,5 +172,13 @@ spec:
         hostPath:
           path: /var/ckan-cloud-{{ .Release.Namespace }}
           type: DirectoryOrCreate
+      {{ end }}
+      {{ if .Values.enableGiftless }}
+      - secret:
+          secretName: jwt-keys
+        name: jwt-key
+      - secret:
+          secretName: jwt-keys
+        name: jwt-key-pub
       {{ end }}
 {{ end }}

--- a/ckan/templates/ckan-deployment.yaml
+++ b/ckan/templates/ckan-deployment.yaml
@@ -1,4 +1,4 @@
-{{ if not .Values.centralizedInfraOnly }}
+  {{ if not .Values.centralizedInfraOnly }}
 apiVersion: apps/v1
 kind: Deployment
 metadata: {name: ckan}
@@ -134,11 +134,9 @@ spec:
         - mountPath: /etc/ssh/jwt-rs256.key
           name: jwt-key
           readOnly: true
-          subPath: jwt-rs256.key
         - mountPath: /etc/ssh/jwt-rs256.key.pub
           name: jwt-key-pub
           readOnly: true
-          subPath: jwt-rs256.key.pub
         {{ end }}
         {{ if not .Values.noProbes }}
         readinessProbe:

--- a/ckan/templates/giftless-configmap.yaml
+++ b/ckan/templates/giftless-configmap.yaml
@@ -1,0 +1,34 @@
+{{ if .Values.enableGiftless }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: giftless
+data:
+  giftless.yaml: |
+    AUTH_PROVIDERS:
+      - factory: giftless.auth.jwt:factory
+        options:
+          algorithm: RS256
+          public_key_file: /etc/ssh/jwt-rs256.key.pub
+
+    TRANSFER_ADAPTERS:
+      basic:
+        factory: giftless.transfer.basic_external:factory
+        options:
+          storage_class: ..storage.azure:AzureBlobsStorage
+          storage_options:
+            connection_string: {{ .Values.excternalStorageConnectionString }}
+            container_name: {{ .Values.excternalStorageContainerName }}
+            path_prefix: {{ .Values.giftlessPathPrefix | default "giftless" | quote }}
+
+    PRE_AUTHORIZED_ACTION_PROVIDER:
+      options:
+        private_key: {{ randAlphaNum 16 | b64enc | quote }}
+
+    MIDDLEWARE:
+      - class: werkzeug.middleware.proxy_fix:ProxyFix
+        kwargs:
+          x_host: 1
+          x_port: 1
+          x_prefix: 1
+{{ end }}

--- a/ckan/templates/giftless-deployment.yaml
+++ b/ckan/templates/giftless-deployment.yaml
@@ -53,8 +53,7 @@ spec:
           subPath: giftless.yaml
       volumes:
       - secret:
-          defaultMode: 420
-          name: jwt-keys
+          secretName: jwt-keys
         name: jwt-key-pub
       - configMap:
           defaultMode: 420

--- a/ckan/templates/giftless-deployment.yaml
+++ b/ckan/templates/giftless-deployment.yaml
@@ -1,0 +1,61 @@
+{{ if .Values.enableGiftless  }}
+apiVersion: apps/v1
+kind: Deployment
+metadata: {name: giftless}
+spec:
+  replicas: 1
+  revisionHistoryLimit: 2
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels: {app: giftless}
+  template:
+    metadata:
+      labels: {app: giftless}
+    spec:
+      containers:
+      - command:
+        - uwsgi
+        - -M
+        - -T
+        - --threads
+        - "2"
+        - -p
+        - "2"
+        - --manage-script-name
+        - --callable
+        - app
+        - --http
+        - 0.0.0.0:5000
+        {{ if .Values.giftlessDebug }}
+        env:
+        - name: GIFTLESS_DEBUG
+          value: "1"
+        {{ end }}
+        image: {{ .Values.giftlessImage | default "datopian/giftless:latest" | quote }}
+        name: giftless
+        ports:
+        - containerPort: 5000
+          protocol: TCP
+        {{ if .Values.giftlessResources }}
+        resources: {{ .Values.giftlessResources }}
+        {{ end }}
+        volumeMounts:
+        - mountPath: /etc/ssh/jwt-rs256.key.pub
+          name: jwt-key-pub
+          readOnly: true
+          subPath: jwt-rs256.key.pub
+        - mountPath: /app/giftless.yaml
+          name: giftless-config
+          readOnly: true
+          subPath: giftless.yaml
+      volumes:
+      - secret:
+          defaultMode: 420
+          name: jwt-keys
+        name: jwt-key-pub
+      - configMap:
+          defaultMode: 420
+          name: giftless
+        name: giftless-config
+{{ end }}

--- a/ckan/templates/giftless-deployment.yaml
+++ b/ckan/templates/giftless-deployment.yaml
@@ -32,6 +32,8 @@ spec:
         - name: GIFTLESS_DEBUG
           value: "1"
         {{ end }}
+        - name: GIFTLESS_CONFIG_FILE
+          value: /app/giftless.yaml
         image: {{ .Values.giftlessImage | default "datopian/giftless:latest" | quote }}
         name: giftless
         ports:

--- a/ckan/templates/giftless-deployment.yaml
+++ b/ckan/templates/giftless-deployment.yaml
@@ -27,8 +27,8 @@ spec:
         - app
         - --http
         - 0.0.0.0:5000
-        {{ if .Values.giftlessDebug }}
         env:
+        {{ if .Values.giftlessDebug }}
         - name: GIFTLESS_DEBUG
           value: "1"
         {{ end }}

--- a/ckan/templates/giftless-secrets.yaml
+++ b/ckan/templates/giftless-secrets.yaml
@@ -4,6 +4,6 @@ kind: Secret
 metadata:
   name: jwt-keys
 data:
-  jwt-rs256.key: {{ .Values.jwtKey }}
-  jwt-rs256.key.pub: {{ .Values.jwtKeyPub }}
+  jwt-rs256.key: {{ .Values.CkanAuthzJwtKey }}
+  jwt-rs256.key.pub: {{ .Values.CkanAuthzJwtKeyPub }}
 {{ end }}

--- a/ckan/templates/giftless-secrets.yaml
+++ b/ckan/templates/giftless-secrets.yaml
@@ -1,0 +1,9 @@
+{{ if .Values.enableGiftless }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: jwt-keys
+data:
+  jwt-rs256.key: {{ .Values.jwtKey }}
+  jwt-rs256.key.pub: {{ .Values.jwtKeyPub }}
+{{ end }}

--- a/ckan/templates/giftless-service.yaml
+++ b/ckan/templates/giftless-service.yaml
@@ -1,0 +1,9 @@
+{{ if .Values.enableGiftless }}
+apiVersion: v1
+kind: Service
+metadata: {name: giftless}
+spec:
+  ports:
+  - {name: '5000', port: 5000}
+  selector: {app: giftless}
+{{ end }}

--- a/ckan/templates/nginx-configmap.yaml
+++ b/ckan/templates/nginx-configmap.yaml
@@ -25,9 +25,9 @@ data:
 {{ end }}
 
 {{ if .Values.enableGiftless }}
-        location /{{ .Values.giftlessProxyPrefix | default "giftless" | quote }}/ {
+        location /{{ .Values.giftlessProxyPrefix | default giftless | quote }}/ {
             proxy_pass http://giftless:5000/;
-            proxy_set_header X-Forwarded-Prefix /{{ .Values.giftlessProxyPrefix | default "giftless" | quote }};
+            proxy_set_header X-Forwarded-Prefix /{{ .Values.giftlessProxyPrefix | default giftless | quote }};
         }
 {{ end }}
         location / {

--- a/ckan/templates/nginx-configmap.yaml
+++ b/ckan/templates/nginx-configmap.yaml
@@ -25,9 +25,9 @@ data:
 {{ end }}
 
 {{ if .Values.enableGiftless }}
-        location /{{ .Values.giftlessProxyPrefix | default giftless | quote }}/ {
+        location /giftless/ {
             proxy_pass http://giftless:5000/;
-            proxy_set_header X-Forwarded-Prefix /{{ .Values.giftlessProxyPrefix | default giftless | quote }};
+            proxy_set_header X-Forwarded-Prefix /giftless;
         }
 {{ end }}
         location / {

--- a/ckan/templates/nginx-configmap.yaml
+++ b/ckan/templates/nginx-configmap.yaml
@@ -20,7 +20,14 @@ data:
             proxy_redirect off;
             proxy_http_version 1.1;
             proxy_set_header Upgrade $http_upgrade;
-            proxy_set_header Connection "upgrade";       
+            proxy_set_header Connection "upgrade";
+        }
+{{ end }}
+
+{{ if .Values.enableGiftless }}
+        location /{{ .Values.giftlessProxyPrefix | default "giftless" | quote }}/ {
+            proxy_pass http://giftless:5000/;
+            proxy_set_header X-Forwarded-Prefix /{{ .Values.giftlessProxyPrefix | default "giftless" | quote }};
         }
 {{ end }}
         location / {


### PR DESCRIPTION
Giftless a Python implementation of a Git LFS Server https://github.com/datopian/giftless. 

PR includes templates to deploy the Git LFS server on ckan-cloud-clusters

- Secrets for mounting private and public RSA keys
  - Also, mount in ckan pods for https://github.com/datopian/ckanext-authz-service
- Configmap for giftless config
- deployment and service templates
- Proxy giftless requests (for browser requests)