### PR TITLE
[ingress][xs]: default backend - 404

### DIFF
--- a/ckan/templates/ckan-ingress.yaml
+++ b/ckan/templates/ckan-ingress.yaml
@@ -5,7 +5,6 @@ metadata:
   name: ckan-ingress-ingress
   annotations:
     kubernetes.io/ingress.class: nginx
-    nginx.ingress.kubernetes.io/rewrite-target: /$1
     nginx.ingress.kubernetes.io/proxy-body-size: {{ .Values.nginxIngressMaxBodySize | default "1000M" }}
     {{ if .Values.enableGiftless }}
     nginx.ingress.kubernetes.io/configuration-snippet: |
@@ -26,11 +25,11 @@ spec:
       - backend:
           serviceName: ckan
           servicePort: 5000
-        path: /(.*)
+        path: /
       {{ if .Values.enableGiftless }}
       - backend:
           serviceName: giftless
           servicePort: 5000
-        path: /giftless/(.*)
+        path: /giftless/
       {{ end }}
 {{ end }}


### PR DESCRIPTION
We were getting default backend - 404 on some environment cause rule was
not reading path or regex properly.