### PR TITLE
Fix typos in ckan-configmap.yaml

### DIFF
--- a/ckan/templates/ckan-configmap.yaml
+++ b/ckan/templates/ckan-configmap.yaml
@@ -199,7 +199,7 @@ data:
     {{ if .Values.ckanSmtpServer }}
     smtp.server = {{ .Values.ckanSmtpServer }}
     smtp.starttls = {{ .Values.ckanSmtpStarttls }}
-    smtp.user = {{ .Values.ckanSmtpUuser }}
+    smtp.user = {{ .Values.ckanSmtpUser }}
     smtp.password = {{ .Values.ckanSmtpPassword }}
     smtp.mail_from = {{ .Values.ckanSmtpMail_from }}
     {{ else }}

--- a/ckan/templates/ckan-configmap.yaml
+++ b/ckan/templates/ckan-configmap.yaml
@@ -197,11 +197,11 @@ data:
     #email_to = errors@example.com
     #error_email_from = ckan-errors@example.com
     {{ if .Values.ckanSmtpServer }}
-    smtp.server = {{ .Valuse.ckanSmtpServer }}
-    smtp.starttls = {{ .Valuse.ckanSmtpStarttls }}
-    smtp.user = {{ .Valuse.ckanSmtpUuser }}
-    smtp.password = {{ .Valuse.ckanSmtpPassword }}
-    smtp.mail_from = {{ .Valuse.ckanSmtpMail_from }}
+    smtp.server = {{ .Values.ckanSmtpServer }}
+    smtp.starttls = {{ .Values.ckanSmtpStarttls }}
+    smtp.user = {{ .Values.ckanSmtpUuser }}
+    smtp.password = {{ .Values.ckanSmtpPassword }}
+    smtp.mail_from = {{ .Values.ckanSmtpMail_from }}
     {{ else }}
     smtp.server = {{ "{{" }}SMTP_SERVER{{ "}}" }}
     smtp.starttls = {{ "{{" }}SMTP_STARTTLS{{ "}}" }}


### PR DESCRIPTION
This PR fixes some typos in the `ckan-configmap.yaml` file