### PR TITLE
Update giftless storage_class

### DIFF
--- a/ckan/templates/giftless-configmap.yaml
+++ b/ckan/templates/giftless-configmap.yaml
@@ -15,7 +15,7 @@ data:
       basic:
         factory: giftless.transfer.basic_external:factory
         options:
-          storage_class: ..storage.azure:AzureBlobsStorage
+          storage_class: giftless.storage.azure:AzureBlobsStorage
           storage_options:
             connection_string: {{ .Values.excternalStorageConnectionString }}
             container_name: {{ .Values.excternalStorageContainerName }}


### PR DESCRIPTION
This PR updates the giftless storage_class to work with the [latest refactor](https://github.com/datopian/giftless/pull/29) of giftless. This PR fixes the following error when deploying:

```
*** Operational MODE: preforking+threaded ***
Traceback (most recent call last):
  File "./giftless/wsgi_entrypoint.py", line 7, in <module>
    app = init_app()
  File "./giftless/app.py", line 43, in init_app
    transfer.init_flask_app(app)
  File "./giftless/transfer/__init__.py", line 76, in init_flask_app
    adapters = {k: _init_adapter(v) for k, v in config.items()}
  File "./giftless/transfer/__init__.py", line 76, in <dictcomp>
    adapters = {k: _init_adapter(v) for k, v in config.items()}
  File "./giftless/transfer/__init__.py", line 101, in _init_adapter
    adapter: TransferAdapter = factory(**config.get('options', {}))
  File "./giftless/transfer/basic_external.py", line 84, in factory
    storage = get_callable(storage_class, __name__)
  File "./giftless/util.py", line 19, in get_callable
    module = importlib.import_module(module_name, base_package)
  File "/usr/local/lib/python3.7/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
ModuleNotFoundError: No module named 'giftless.transfer.storage'
```