### PR TITLE
Add readinessProbe to jobs deployment

### DIFF
--- a/ckan/templates/jobs-deployment.yaml
+++ b/ckan/templates/jobs-deployment.yaml
@@ -92,6 +92,18 @@ spec:
         - name: ckan-conf-templates-jobs
           mountPath: /etc/ckan-conf/templates
           readOnly: true
+        {{ if not .Values.noProbes }}
+        readinessProbe:
+          exec:
+            command:
+            - /bin/sh
+            - -c
+            - if ! ps -x | grep "bin/ckan jobs worker" | grep -v grep > /dev/null; then echo "Jobs worker are not running."; fi;
+          initialDelaySeconds: {{ .Values.ckanReadinessInitialDelaySeconds | default "30" }}
+          periodSeconds: {{ .Values.ckanReadinessPeriodSeconds | default "5" }}
+          timeoutSeconds: {{ .Values.ckanReadinessTimeoutSeconds | default "10" }}
+          failureThreshold: {{ .Values.ckanReadinessFailureThreshold | default "15" }}
+        {{ end }}
       volumes:
       - name: ckan-conf-secrets-jobs
         emptyDir: {}

--- a/ckan/templates/jobs-deployment.yaml
+++ b/ckan/templates/jobs-deployment.yaml
@@ -93,7 +93,7 @@ spec:
           mountPath: /etc/ckan-conf/templates
           readOnly: true
         {{ if not .Values.noProbes }}
-        readinessProbe:
+        livenessProbe:
           exec:
             command:
             - /bin/sh


### PR DESCRIPTION
This PR adds a readiness probe to ensure that the jobs command has been executed successfully.

This way we can ensure that the pod contains running workers. This will allow silent failings due that the pod is up. but there are no workers running on it.